### PR TITLE
Changed order, because typedefs were not available in includes.

### DIFF
--- a/socket/main.h
+++ b/socket/main.h
@@ -21,6 +21,16 @@
 	#include "unistd.h"
 	#include "pthread.h"
 #endif
+
+#ifdef WIN32
+	#define SLEEP(x) { Sleep(x); }
+#else
+	#define SLEEP(x) { usleep(x * 1000); }
+	#define SOCKET_ERROR (-1)
+	typedef unsigned long DWORD;
+	typedef unsigned int UINT;
+#endif
+
 #include "queue"
 #include "list"
 #include "string.h"
@@ -32,15 +42,6 @@
 
 #define VERSION "0.2a"
 #define INVALID_CLIENT_ID (-1)
-
-#ifdef WIN32
-	#define SLEEP(x) { Sleep(x); }
-#else
-	#define SLEEP(x) { usleep(x * 1000); }
-	#define SOCKET_ERROR (-1)
-	typedef unsigned long DWORD;
-	typedef unsigned int UINT;
-#endif
 
 typedef void (*logprintf_t)(char* format, ...);
 


### PR DESCRIPTION
The plugin did not compile on my linux box, because DWORD was not defined in CSocket.h and CThread.h included from main.h. Fixed this by putting the typedefs above the includes.
